### PR TITLE
Allow re-setting the colorscheme to 1989

### DIFF
--- a/colors/1989.vim
+++ b/colors/1989.vim
@@ -28,7 +28,7 @@ let s:dark_blue = [31, "#0087af"]
 
 let s:none = ["NONE", ""]
 
-fun <SID>set_hi(name, fg, bg, style)
+function! <SID>set_hi(name, fg, bg, style)
   execute "hi " . a:name . " ctermfg=" . a:fg[0] . " ctermbg=" . a:bg[0] " cterm=" . a:style
   if a:fg[1] != ""
     execute "hi " . a:name . " guifg=" . a:fg[1]


### PR DESCRIPTION
I had my colorscheme set to 1989 in my vimrc, then did this:

```
:colorscheme jellybeans
:colorscheme 1989
```

When I ran the second command, resetting my colorscheme to 1989 and thus
re-sourcing the `1989.vim` file, I got the following error:

```
E122: Function <SNR>55_set_hi already exists, add ! to replace it
```

Using `function!` instead of `fun` fixes the error.
