### PR TITLE
Highlight Markdown headers

### DIFF
--- a/colors/1989.vim
+++ b/colors/1989.vim
@@ -157,3 +157,12 @@ call <SID>set_hi("coffeeCurly", s:lavender, s:none, "NONE")
 call <SID>set_hi("coffeeObjAssign", s:light_purple, s:none, "NONE")
 
 call <SID>set_hi("cjsxAttribProperty", s:lavender, s:none, "NONE")
+
+call <SID>set_hi("markdownH1", s:light_blue, s:none, "NONE")
+call <SID>set_hi("markdownH2", s:light_blue, s:none, "NONE")
+call <SID>set_hi("markdownH3", s:light_blue, s:none, "NONE")
+call <SID>set_hi("markdownH4", s:light_blue, s:none, "NONE")
+call <SID>set_hi("markdownH5", s:light_blue, s:none, "NONE")
+call <SID>set_hi("markdownH6", s:light_blue, s:none, "NONE")
+call <SID>set_hi("markdownHeadingDelimiter", s:light_blue, s:none, "NONE")
+call <SID>set_hi("markdownRule", s:light_blue, s:none, "NONE")


### PR DESCRIPTION
This makes every part of the markdown header the same color. I chose light blue because it stands out a bit, but I am of course open to any other color.
- `markdownHeadingDelimiter` is the `###` in `<h3>`s
- `markdownRule` is the underline in some markdown heading rules. It might map
  to something else, as well, but I couldn't figure out what it might break.

---

Before:

![terminal 2016-05-27 08-12-16](https://cloud.githubusercontent.com/assets/257678/15612238/bf441558-23e2-11e6-926a-e5fe0d39dd68.png)

---

After:

![after](https://cloud.githubusercontent.com/assets/257678/15590771/2df21580-234e-11e6-9972-1b72d9dc5d54.png)
