### PR TITLE
Improve TODO readability

### DIFF
--- a/colors/1989.vim
+++ b/colors/1989.vim
@@ -91,7 +91,7 @@ call <SID>set_hi("StorageClass", s:mint, s:none, "NONE")
 call <SID>set_hi("String", s:light_blue, s:none, "NONE")
 call <SID>set_hi("Tag", s:pink, s:none, "NONE")
 call <SID>set_hi("Title", s:default_white, s:none, "bold")
-call <SID>set_hi("Todo", s:light_yellow, s:none, "inverse,bold")
+call <SID>set_hi("Todo", s:light_yellow, s:dark_gray, "bold")
 call <SID>set_hi("Type", s:mint, s:none, "NONE")
 call <SID>set_hi("Underlined", s:none, s:none, "underline")
 


### PR DESCRIPTION
This may come down to personal preference, seeing if anyone else would like this change too.

From this:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/1e3O3Z1z0D3r2z181L3o/Image%202017-04-21%20at%201.40.29%20pm.png)

To this:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/3H3q1G2U251m0B372n0K/Image%202017-04-21%20at%201.40.05%20pm.png)