### PR TITLE
Add light_gray color for use with CursorLine, CursorColumn and ColorColumn.

### DIFF
--- a/colors/1989.vim
+++ b/colors/1989.vim
@@ -11,6 +11,7 @@ let g:colors_name = "1989"
 
 let s:dark_gray = [236, "#303030"]
 let s:mid_gray = [102, "#878787"]
+let s:light_gray = [238, "#444444"]
 let s:default_white = [231, "#FFFFFF"]
 
 let s:lavender = [183, "#dfafff"]
@@ -42,9 +43,9 @@ endfun
 call <SID>set_hi("Normal", s:default_white, s:dark_gray, "NONE")
 call <SID>set_hi("Cursor", s:dark_gray, s:default_white, "NONE")
 call <SID>set_hi("Visual", s:none, s:mid_gray, "NONE")
-call <SID>set_hi("CursorLine", s:none, s:dark_gray, "NONE")
-call <SID>set_hi("CursorColumn", s:none, s:dark_gray, "NONE")
-call <SID>set_hi("ColorColumn", s:none, s:dark_gray, "NONE")
+call <SID>set_hi("CursorLine", s:none, s:light_gray, "NONE")
+call <SID>set_hi("CursorColumn", s:none, s:light_gray, "NONE")
+call <SID>set_hi("ColorColumn", s:none, s:light_gray, "NONE")
 call <SID>set_hi("LineNr", s:mid_gray, s:dark_gray, "NONE")
 call <SID>set_hi("VertSplit", s:mid_gray, s:mid_gray, "NONE")
 call <SID>set_hi("MatchParen", s:pink, s:none, "underline")


### PR DESCRIPTION
Currently, the color set for the CursorLine, CursorColumn and ColorColumn groups is the same as the background color, which makes these features unusable with the color scheme.
I have added a new color, 'light_gray', which is just a touch lighter than mid_gray, and assigned that color to the above mentioned groups.